### PR TITLE
[grafana] Ensure grafana starts on boot. Needed on Debian buster.

### DIFF
--- a/ansible/roles/grafana/defaults/main.yml
+++ b/ansible/roles/grafana/defaults/main.yml
@@ -49,7 +49,6 @@ grafana__upstream_apt_id: '4E40 DDF6 D76E 284A 4A67  80E4 8C8C 34C5 2409 8CB6'
 grafana__upstream_apt_repository: 'deb https://packages.grafana.com/oss/deb stable main'
 
                                                                    # ]]]
-
 # .. envvar:: grafana__base_packages [[[
 #
 # List of APT packages which are required by the Grafana role.

--- a/ansible/roles/grafana/tasks/main.yml
+++ b/ansible/roles/grafana/tasks/main.yml
@@ -36,6 +36,11 @@
     - 'etc/grafana/ldap.toml'
   notify: [ 'Restart grafana' ]
 
+- name: Ensure grafana starts on boot
+  service:
+    name: 'grafana-server'
+    enabled: True
+
 - name: Make sure that Ansible local facts directory exists
   file:
     path: '/etc/ansible/facts.d'


### PR DESCRIPTION
Updates: https://github.com/debops/debops/pull/1124